### PR TITLE
Use standardized `maintainer` metadata property value

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,7 +1,7 @@
 name=Arduino_10BASE_T1S
 version=0.1.0
 author=Alexander Entinger <a.entinger@arduino.cc>
-maintainer=Alexander Entinger <a.entinger@arduino.cc>
+maintainer=Arduino <info@arduino.cc>
 sentence=Generic library for providing IP based 10BASE-T1S communication.
 paragraph=This Arduino library provides both low-level drivers and high-level abstractions to perform real-time communication via 10BASE-T1S, a multi-drop capable Ethernet standard.
 category=Communication


### PR DESCRIPTION
The `maintainer` property of the library.properties metadata file defines the entity responsible for maintenance of the library.

In the libraries that are under Arduino's maintainership, it is standard practice to set the `maintainer` property to the general purpose value "Arduino <info@arduino.cc>".

Previously, instead of that standard value, this library's `maintainer` property defined a specific Arduino team member as the maintainer. This is prone to "bit rot", as the scope of each individual's work may change over time, or they may even move on from working for Arduino. It is unlikely that the team member will remember to update the metadata values at such time as they are no longer able to dedicate themselves to maintaining the library. So the metadata is changed to use the standard value.

It is commendable for individual team members to take responsibility for maintenance of specific libraries. However, doing so is not in any way dependent on the value of a metadata property. The change to the metadata does not imply any change to maintenance responsibilities for the project.